### PR TITLE
Remove treasure hunt card and fix SideNav arcade glitch

### DIFF
--- a/src/components/SideNav/index.js
+++ b/src/components/SideNav/index.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 import { withRouter } from 'react-router-dom';
 import { Box, Button, Heading } from 'grommet';
 
@@ -8,6 +9,10 @@ const getNavColor = (active, hover) => {
   if (hover) return 'white';
   return 'rgba(255, 255, 255, 0.3)';
 };
+
+const SideNavContainer = styled(Box)`
+  z-index: 1;
+`;
 
 const NavButton = ({ active, to, history, children, size }) => {
   const [hover, setHover] = useState(false);
@@ -45,7 +50,7 @@ NavButton.propTypes = {
 };
 
 const SideNav = ({ location, history, size, match }) => (
-  <Box align="start" gap="xsmall" width={{ min: '250px' }}>
+  <SideNavContainer align="start" gap="xsmall" width={{ min: '250px' }}>
     <NavButton
       history={history}
       active={location.pathname === '/'}
@@ -106,7 +111,7 @@ const SideNav = ({ location, history, size, match }) => (
     >
       ARCADE
     </NavButton>
-  </Box>
+  </SideNavContainer>
 );
 
 SideNav.propTypes = {

--- a/src/data/CardData/PageContent.js
+++ b/src/data/CardData/PageContent.js
@@ -71,16 +71,16 @@ export const arcadeContent = [
     label: 'Play the Game',
     background: 'background',
   },
-  {
-    image: '/img/Arcade/TreasureMap.png',
-    alt: 'Treasure hunt map',
-    title: 'HPE DEV TREASURE HUNT',
-    desc:
-      "Explore the HPE Developer Community's rich ecosystem in this scavenger-hunt style game!",
-    link: 'https://forms.office.com/r/SDRAJVxEAd',
-    label: 'Hunt for Treasure!',
-    background: 'background',
-  },
+  // {
+  //   image: '/img/Arcade/TreasureMap.png',
+  //   alt: 'Treasure hunt map',
+  //   title: 'HPE DEV TREASURE HUNT',
+  //   desc:
+  //     "Explore the HPE Developer Community's rich ecosystem in this scavenger-hunt style game!",
+  //   link: 'https://forms.office.com/r/SDRAJVxEAd',
+  //   label: 'Hunt for Treasure!',
+  //   background: 'background',
+  // },
   {
     image: '/img/Arcade/rockingGremlin.png',
     alt: 'Gremlin',

--- a/src/pages/Home/index.js
+++ b/src/pages/Home/index.js
@@ -138,7 +138,7 @@ const Cards = ({ size }) => (
           : { top: 'xlarge', right: 'large' }
       }
     />
-    {/* <Card
+    <Card
       image="/img/munch-and-learn-3.jpg"
       title="Introducing HPE DEV Munch & Learn series"
       desc="Session 5: Data Science Unplugged Part 2."
@@ -146,8 +146,8 @@ const Cards = ({ size }) => (
       background="rgba(0, 86, 122, 0.8);"
       label="Register Now!"
       margin={size === 'small' ? { bottom: 'none' } : { bottom: 'xlarge' }}
-    /> */}
-    <Card
+    />
+    {/* <Card
       image="/img/Arcade/TreasureMap.png"
       title="WIN IN THE HPE DEV TREASURE HUNT"
       desc="Discover ways to collaborate and where to find resources."
@@ -155,7 +155,7 @@ const Cards = ({ size }) => (
       background="rgba(0, 86, 122, 0.8);"
       label="Hunt for Treasure!"
       margin={size === 'small' ? { bottom: 'none' } : { bottom: 'xlarge' }}
-    />
+    /> */}
     {/* <Card
       logo="/img/Community/dev-thumb.png"
       title="GET THE HPE DEVELOPER NEWSLETTER"


### PR DESCRIPTION
### Home Page
- Comment out Treasure Hunt card
- Add Munch and Learn Session: 5
- Add `z-index: 1` to `SideNav` component so that the **Arcade** menu item is not hiding behind the container image below. 

### Arcade Page
- Comment out Treasure Hunt card